### PR TITLE
Added support for PHPUnit 9, dropped support for PHPUnit 7 and PHP < 7.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /tools
 /vendor
 /build.properties
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
-  - 7.1
-  - 7.2
   - 7.3
+  - 7.4
+  - 8.0
 
 env:
   global:
@@ -14,13 +14,10 @@ env:
 
 matrix:
   include:
-    - php: 7.1
-      env: PHPUNIT_VERSION=^7.0 EXTRA_COMPOSER_FLAGS=--prefer-lowest
-    - php: 7.2
+    - php: 7.3
       env: PHPUNIT_VERSION=^8.0 EXTRA_COMPOSER_FLAGS=--prefer-lowest
-  exclude:
-    - php: 7.1
-      env: PHPUNIT_VERSION=^8.0
+    - php: 7.4
+      env: PHPUNIT_VERSION=^8.0 EXTRA_COMPOSER_FLAGS=--prefer-lowest
 
 before_install: composer require phpunit/phpunit:$PHPUNIT_VERSION --no-update
 

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,10 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.3",
         "ext-dom": "*",
         "ext-json": "*",
-        "phpunit/phpunit": "^7.0 || ^8.0"
+        "phpunit/phpunit": "^8.0 || ^9.0"
     },
     "autoload": {
         "classmap": [
@@ -21,4 +21,3 @@
         ]
     }
 }
-

--- a/src/Constraint/XpathEquals.php
+++ b/src/Constraint/XpathEquals.php
@@ -41,7 +41,7 @@ class XpathEquals extends Xpath
      *
      * @throws \PHPUnit\Framework\ExpectationFailedException
      */
-    public function evaluate($other, $description = '', $returnResult = false)
+    public function evaluate($other, string $description = '', bool $returnResult = false): ?bool
     {
         $actual = $this->evaluateXpathAgainst($other);
         try {

--- a/tests/AssertTest.php
+++ b/tests/AssertTest.php
@@ -25,8 +25,8 @@ class AssertTest extends TestCase
     public function testAssertXpathMatchFailure()
     {
         $this->expectException(AssertionFailedError::class);
-        $this->expectExceptionMessageRegExp(
-            '(Failed asserting that DOMDocument Object .* matches expression: //non-existing\\.)'
+        $this->expectExceptionMessageMatches(
+            '#(Failed asserting that DOMDocument Object .* matches expression: //non-existing\\.)#ms'
         );
         self::assertXpathMatch('//non-existing', $this->getXMLDocument());
     }


### PR DESCRIPTION
Hello,

once again it seems I'm the only one using a library. :)

I've added and tested support for PHPUnit 9.0. Therefore I had to drop PHPUnit 7, since an interface has changed (added type hints) and PHPUnit 8 won't execute on PHP lower then 7.3.

The good news is: this library is compatible with the current development version of PHPUnit 10 (which is likely to change) and I've executed the test on PHP 8.1RC1 and fixed the test for that version in advance.

Side note: to test this with PHPUnit 10 execute this Composer command (PHPUnit 10 requires PHP 8):

```bash
composer require phpunit/phpunit="dev-master as 10.0" \
  sebastian/code-unit="2.0.x-dev as 2.0" \
  phpunit/php-code-coverage="10.0.x-dev as 10.0" \
  sebastian/version="4.0.x-dev as 4.0" \
  sebastian/type="3.0.x-dev as 3.0" \
  phpunit/php-file-iterator="4.0.x-dev as 4.0" \
  sebastian/cli-parser="2.0.x-dev as 2.0" \
  phpunit/php-timer="6.0.x-dev as 6.0" \
  phpunit/php-invoker="4.0.x-dev as 4.0" \
  sebastian/exporter="5.0.x-dev as 5.0" \
  sebastian/comparator="5.0.x-dev as 5.0" \
  phpunit/php-text-template="3.0.x-dev as 3.0" \
  sebastian/environment="6.0.x-dev as 6.0" \
  sebastian/diff="5.0.x-dev as 5.0" \
  sebastian/global-state="6.0.x-dev as 6.0" \
  sebastian/object-enumerator="5.0.x-dev as 5.0" \
  sebastian/lines-of-code="2.0.x-dev as 2.0" \
  sebastian/complexity="3.0.x-dev as 3.0" \
  sebastian/code-unit-reverse-lookup="3.0.x-dev as 3.0" \
  sebastian/recursion-context="5.0.x-dev as 5.0" \
  sebastian/object-reflector="3.0.x-dev as 3.0" -W
```