### PR TITLE
Added support for PHPUnit 10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /vendor
 /build.properties
 .phpunit.result.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.4 || ~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-dom": "*",
         "ext-json": "*",
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^9.0 || ^10.0"
     },
     "autoload": {
         "classmap": [

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,11 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-    bootstrap="vendor/autoload.php" forceCoversAnnotation="false"
-    beStrictAboutCoversAnnotation="false" beStrictAboutOutputDuringTests="true"
-    beStrictAboutTodoAnnotatedTests="true">
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.0/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         beStrictAboutOutputDuringTests="true"
+         cacheDirectory=".phpunit.cache"
+         requireCoverageMetadata="false"
+         beStrictAboutCoverageMetadata="false">
 
-    <coverage processUncoveredFiles="true">
+    <coverage>
         <include>
             <directory suffix=".php">src</directory>
         </include>


### PR DESCRIPTION
Here we got support for PHPUnit 10.

`SebastianBergmann\Comparator\ComparisonFailure` removed one constructor parameter, so therefore I've added a test to check for number of arguments. If this is not done we would need to remove support for PHP<8.1 and PHPUnit 9.